### PR TITLE
[fix] Flowers cannot be placed side by side on farmland

### DIFF
--- a/src/material/block/plant/CyanFlowerBlock.php
+++ b/src/material/block/plant/CyanFlowerBlock.php
@@ -14,7 +14,7 @@ class CyanFlowerBlock extends FlowableBlock{
 	
 	public function place(Item $item, Player $player, Block $block, Block $target, $face, $fx, $fy, $fz){
 			$down = $this->getSide(0);
-			if($down->getID() === 2 or $down->getID() === 3 or $down->getID() === 60){
+			if($down->getID() === GRASS or $down->getID() === DIRT or $down->getID() === FARMLAND){
 				$this->level->setBlock($block, $this, true, false, true);
 				return true;
 			}
@@ -22,7 +22,8 @@ class CyanFlowerBlock extends FlowableBlock{
 	}
 
 	public static function neighborChanged(Level $level, $x, $y, $z, $nX, $nY, $nZ, $oldID){
-		if(StaticBlock::getIsTransparent($level->level->getBlockID($x, $y - 1, $z))){ //Replace with common break method
+		$downId = $level->level->getBlockID($x, $y - 1, $z);
+		if(StaticBlock::getIsTransparent($downId) and $downId !== FARMLAND){ //Replace with common break method
 			ServerAPI::request()->api->entity->drop(new Position($x+0.5, $y, $z+0.5, $level), BlockAPI::getItem(CYAN_FLOWER));
 			$level->fastSetBlockUpdate($x, $y, $z, 0, 0);
 		}

--- a/src/material/block/plant/CyanFlowerBlock.php
+++ b/src/material/block/plant/CyanFlowerBlock.php
@@ -11,15 +11,16 @@ class CyanFlowerBlock extends FlowableBlock{
 	public static function getAABB(Level $level, $x, $y, $z){
 		return null;
 	}
-	
+
 	public function place(Item $item, Player $player, Block $block, Block $target, $face, $fx, $fy, $fz){
-			$down = $this->getSide(0);
-			if($down->getID() === GRASS or $down->getID() === DIRT or $down->getID() === FARMLAND){
-				$this->level->setBlock($block, $this, true, false, true);
-				return true;
-			}
+		$down = $this->getSide(0);
+		if($down->getID() === GRASS or $down->getID() === DIRT or $down->getID() === FARMLAND){
+			$this->level->setBlock($block, $this, true, false, true);
+			return true;
+		}
 		return false;
 	}
+
 
 	public static function neighborChanged(Level $level, $x, $y, $z, $nX, $nY, $nZ, $oldID){
 		$downId = $level->level->getBlockID($x, $y - 1, $z);

--- a/src/material/block/plant/DandelionBlock.php
+++ b/src/material/block/plant/DandelionBlock.php
@@ -11,17 +11,18 @@ class DandelionBlock extends FlowableBlock{
 		return null;
 	}
 	public function place(Item $item, Player $player, Block $block, Block $target, $face, $fx, $fy, $fz){
-			$down = $this->getSide(0);
-			if($down->getID() === 2 or $down->getID() === 3 or $down->getID() === 60){
-				$this->level->setBlock($block, $this, true, false, true);
-				return true;
-			}
+		$down = $this->getSide(0);
+		if($down->getID() === GRASS or $down->getID() === DIRT or $down->getID() === FARMLAND){
+			$this->level->setBlock($block, $this, true, false, true);
+			return true;
+		}
 		return false;
 	}
 
 	public static function neighborChanged(Level $level, $x, $y, $z, $nX, $nY, $nZ, $oldID){
-		if(StaticBlock::getIsTransparent($level->level->getBlockID($x, $y - 1, $z))){ //Replace with common break method
-			ServerAPI::request()->api->entity->drop(new Position($x+0.5, $y, $z+0.5, $level), BlockAPI::getItem(DANDELION));
+		$downId = $level->level->getBlockID($x, $y - 1, $z);
+		if(StaticBlock::getIsTransparent($downId) and $downId !== FARMLAND){ //Replace with common break method
+			ServerAPI::request()->api->entity->drop(new Position($x+0.5, $y, $z+0.5, $level), BlockAPI::getItem(CYAN_FLOWER));
 			$level->fastSetBlockUpdate($x, $y, $z, 0, 0);
 		}
 	}

--- a/src/material/block/plant/SaplingBlock.php
+++ b/src/material/block/plant/SaplingBlock.php
@@ -44,7 +44,8 @@ class SaplingBlock extends FlowableBlock{
 		return false;
 	}
 	public static function neighborChanged(Level $level, $x, $y, $z, $nX, $nY, $nZ, $oldID){
-		if(StaticBlock::getIsTransparent($level->level->getBlockID($x, $y - 1, $z))){ //Replace with common break method
+		$downID = $level->level->getBlockID($x, $y - 1, $z);
+		if(StaticBlock::getIsTransparent($downID) && $downID !== FARMLAND){ //Replace with common break method
 			[$id, $meta] = $level->level->getBlock($x, $y, $z);
 			ServerAPI::request()->api->entity->drop(new Position($x+0.5, $y, $z+0.5, $level), BlockAPI::getItem($id, $meta));
 			$level->fastSetBlockUpdate($x, $y, $z, 0, 0);

--- a/src/material/block/plant/TallGrassBlock.php
+++ b/src/material/block/plant/TallGrassBlock.php
@@ -15,7 +15,8 @@ class TallGrassBlock extends FlowableBlock{
 	}
 
 	public static function neighborChanged(Level $level, $x, $y, $z, $nX, $nY, $nZ, $oldID){
-		if(StaticBlock::getIsTransparent($level->level->getBlockID($x, $y - 1, $z))){ //Replace with common break method
+		$downID = $level->level->getBlockID($x, $y - 1, $z);
+		if(StaticBlock::getIsTransparent($downID) && $downID !== FARMLAND){ //Replace with common break method
 			if(Utils::chance(15)) ServerAPI::request()->api->entity->drop(new Position($x+0.5, $y, $z+0.5, $level), BlockAPI::getItem(WHEAT_SEEDS));
 			$level->fastSetBlockUpdate($x, $y, $z, 0, 0);
 		}
@@ -34,7 +35,7 @@ class TallGrassBlock extends FlowableBlock{
 	
 	public function place(Item $item, Player $player, Block $block, Block $target, $face, $fx, $fy, $fz){
 		$down = $this->getSide(0);
-		if($down->getID() == 2 or $down->getID() == 3){
+		if($down->getID() == GRASS or $down->getID() == DIRT || $down->getID() == FARMLAND){
 			$this->level->setBlock($block, $this, true, false, true);
 			return true;
 		} 


### PR DESCRIPTION
Flowers cannot be placed side by side
In fact, it can do this in vanilla

![Screenshot_2024-08-14-10-30-59-482_com mojang min](https://github.com/user-attachments/assets/de32f512-b849-4d4f-9682-1741103fb4c6)

