### PR TITLE
Fixed timezone error caused by WMIC deprecation in new Windows

### DIFF
--- a/src/config_post.php
+++ b/src/config_post.php
@@ -39,34 +39,70 @@ function parseOffset(string $offset) : string|false{
 
 if(ini_get("date.timezone") == ""){ //No Timezone set
 	date_default_timezone_set("GMT");
-	if(str_contains(" " . strtoupper(php_uname("s")), " WIN")){
-
-		$regex = '/(UTC)(\+*\-*\d*\d*\:*\d*\d*)/';
+	if(str_contains(" " . strtoupper(php_uname("s")), " WIN")){ //windows
+		$keyPath = 'HKLM\\SYSTEM\\CurrentControlSet\\Control\\TimeZoneInformation';
+		$timezone = 'UTC'; //default
 
 		/*
-		 * wmic timezone get Caption
-		 * Get the timezone offset
+		 * Get the timezone offset through the registry
 		 *
 		 * Sample Output var_dump
-		 * array(3) {
-		 *	  [0] =>
-		 *	  string(7) "Caption"
-		 *	  [1] =>
-		 *	  string(20) "(UTC+09:30) Adelaide"
-		 *	  [2] =>
-		 *	  string(0) ""
-		 *	}
+		 * array(13) {
+		 *   [0]=>
+		 *   string(0) ""
+		 *   [1]=>
+		 *   string(71) "HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Control\TimeZoneInformation"
+		 *   [2]=>
+		 *   string(35) "    Bias    REG_DWORD    0xfffffe20"
+		 *   [3]=>
+		 *   string(43) "    DaylightBias    REG_DWORD    0xffffffc4"
+		 *   [4]=>
+		 *   string(45) "    DaylightName    REG_SZ    @tzres.dll,-571"
+		 *   [5]=>
+		 *   string(67) "    DaylightStart    REG_BINARY    00000000000000000000000000000000"
+		 *   [6]=>
+		 *   string(36) "    StandardBias    REG_DWORD    0x0"
+		 *   [7]=>
+		 *   string(45) "    StandardName    REG_SZ    @tzres.dll,-572"
+		 *   [8]=>
+		 *   string(67) "    StandardStart    REG_BINARY    00000000000000000000000000000000"
+		 *   [9]=>
+		 *   string(52) "    TimeZoneKeyName    REG_SZ    China Standard Time"
+		 *   [10]=>
+		 *   string(51) "    DynamicDaylightTimeDisabled    REG_DWORD    0x0"
+		 *   [11]=>
+		 *   string(45) "    ActiveTimeBias    REG_DWORD    0xfffffe20"
+		 *   [12]=>
+		 *   string(0) ""
+		 * }
 		 */
-		exec("wmic timezone get Caption", $output);
+		exec("reg query " . escapeshellarg($keyPath), $output);
 
-		$string = trim(implode("\n", $output));
+		foreach($output as $line){
+			if(preg_match('/ActiveTimeBias\s+REG_DWORD\s+0x([0-9a-fA-F]+)/', $line, $matches) > 0){
+				$offsetMinutes = ((int) hexdec(trim($matches[1]))) << 32 >> 32; //sign int
 
-		//Detect the Time Zone string
-		preg_match($regex, $string, $matches);
+				if($offsetMinutes === 0){
+					break; //UTC
+				}
 
-		if(!isset($matches[2]) or ($timezone = parseOffset($matches[2])) === false){
-			$timezone = 'UTC';
+				$sign = $offsetMinutes <= 0 ? '+' : '-'; //windows timezone + and - are opposite
+				$absMinutes = abs($offsetMinutes);
+				$hours = floor($absMinutes / 60);
+				$minutes = $absMinutes % 60;
+
+				$offset = sprintf(
+					"%s%02d:%02d",
+					$sign,
+					$hours,
+					$minutes
+				);
+
+				$timezone = parseOffset($offset);
+				break;
+			}
 		}
+
 		if(date_default_timezone_set($timezone)){
 			ini_set("date.timezone", $timezone);
 		}


### PR DESCRIPTION
Server cannot correctly obtain the time zone on Windows 11 and Windows Server 2025

see [PMMP#6721](https://github.com/pmmp/PocketMine-MP/pull/6721/)